### PR TITLE
Masque le clavier lorsque bouton échange ou view est touch

### DIFF
--- a/odysee/Controller/ChangeViewController.swift
+++ b/odysee/Controller/ChangeViewController.swift
@@ -25,6 +25,9 @@ class ChangeViewController: UIViewController, UIPickerViewDelegate, UIPickerView
     
     // MARK: Life Cycle
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -110,6 +113,7 @@ class ChangeViewController: UIViewController, UIPickerViewDelegate, UIPickerView
     
     @IBAction func exchangeButtomTapped(_ sender: UIButton) {
         
+        view.endEditing(true)
         if let numberOfcharactere = euroTextField.text?.count {
             print(numberOfcharactere)
             guard numberOfcharactere > 0 else {

--- a/odysee/StoryBoard/Main.storyboard
+++ b/odysee/StoryBoard/Main.storyboard
@@ -331,7 +331,7 @@
                                                     <action selector="usdChoiceButton:" destination="kZV-ze-qgP" eventType="touchUpInside" id="gjB-9l-eeo"/>
                                                 </connections>
                                             </button>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5rU-1u-zUq">
+                                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5rU-1u-zUq">
                                                 <rect key="frame" x="88" y="0.0" width="328" height="46"/>
                                                 <fontDescription key="fontDescription" name="PingFangSC-Semibold" family="PingFang SC" pointSize="20"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES"/>


### PR DESCRIPTION
Fix: Quand le bouton d'echange est touché le clavier disparaît
Fix: Quand la view est touché le clavier disparaît